### PR TITLE
URL changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Issues and enhancement requests can be submitted in the [Issues tab of this repo
 ## Security
 
 As noted in our [security policy](https://github.com/newrelic/nr1-deployment-analyzer/security/policy), New Relic is committed to the privacy and security of our customers and their data. We believe that providing coordinated disclosure by security researchers and engaging with the security community are important means to achieve our security goals.
-If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [HackerOne](https://hackerone.com/newrelic).
+If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [our bug bounty program](https://docs.newrelic.com/docs/security/security-privacy/information-security/report-security-vulnerabilities/).
 
 ## Contributing
 


### PR DESCRIPTION
We are changed our bug bounty program from HackerOne to BugCrowd and the URL has changed - going via a central page now