### PR TITLE
fix: Migrate openOverlay to openNerdlet

### DIFF
--- a/nerdlets/deployment-analyzer-nerdlet/components/deployments-container.js
+++ b/nerdlets/deployment-analyzer-nerdlet/components/deployments-container.js
@@ -20,17 +20,17 @@ import {
 } from 'semantic-ui-react';
 
 function openChartBuilder(query, account) {
-  const nerdlet = {
-    id: 'data-exploration.nrql-editor',
+  navigation.openNerdlet({
+    id: 'unified-data-exploration.share',
     urlState: {
-      initialActiveInterface: 'nrqlEditor',
-      initialChartType: 'table',
-      initialAccountId: account,
-      initialNrqlValue: query,
-      isViewingQuery: true,
+      widget: {
+        visualization: { id: 'viz.table' },
+        rawConfiguration: {
+          nrqlQueries: [{ query, accountIds: [account] }],
+        },
+      },
     },
-  };
-  navigation.openOverlay(nerdlet);
+  });
 }
 
 function createMarker(timestamp) {

--- a/nerdlets/deployment-analyzer-nerdlet/components/deployments-container.js
+++ b/nerdlets/deployment-analyzer-nerdlet/components/deployments-container.js
@@ -29,7 +29,7 @@ function openChartBuilder(query, account) {
           nrqlQueries: [{ query, accountIds: [account] }],
         },
       },
-    },
+    }
   });
 }
 

--- a/nerdlets/deployment-analyzer-nerdlet/components/deployments-container.js
+++ b/nerdlets/deployment-analyzer-nerdlet/components/deployments-container.js
@@ -26,9 +26,9 @@ function openChartBuilder(query, account) {
       widget: {
         visualization: { id: 'viz.table' },
         rawConfiguration: {
-          nrqlQueries: [{ query, accountIds: [account] }],
-        },
-      },
+          nrqlQueries: [{ query, accountIds: [account] }]
+        }
+      }
     }
   });
 }


### PR DESCRIPTION
The `navigation.openOverlay` API is being removed from the New Relic One platform. This PR migrates the single call site in `deployments-container.js` to `navigation.openNerdlet`, pointing at the `unified-data-exploration.share` nerdlet (the supported replacement for opening the NRQL editor from a third-party nerdpack).

**How to test:**

- Open the deployment analyzer for an APM app, click "Open in chart builder" on one of the deployment-related NRQL queries, and confirm the NRQL editor opens with the original query pre-filled